### PR TITLE
feat: Add sample data seeding functionality

### DIFF
--- a/Portal/app/api/seed-sample-data/route.ts
+++ b/Portal/app/api/seed-sample-data/route.ts
@@ -1,0 +1,155 @@
+import { NextResponse } from "next/server";
+import prisma from "@/app/libs/prismadb";
+import { DeviceStatus, AlertLevel, ScheduleMode, UserRole } from "@prisma/client";
+
+// Helper function to generate random telemetry data
+const generateRandomTelemetry = (baseTime: Date, count: number) => {
+  const telemetry = [];
+  for (let i = 0; i < count; i++) {
+    const timestamp = new Date(baseTime.getTime() + i * 5 * 60000); // 5 minutes apart
+    telemetry.push({
+      timestamp,
+      voltage: [220 + Math.random() * 10, 221 + Math.random() * 10, 219 + Math.random() * 10].map(v => parseFloat(v.toFixed(2))),
+      current: [5 + Math.random() * 5, 5.5 + Math.random() * 5, 4.5 + Math.random() * 5].map(c => parseFloat(c.toFixed(2))),
+      power: [1.0 + Math.random() * 0.5, 1.1 + Math.random() * 0.5, 0.9 + Math.random() * 0.5].map(p => parseFloat(p.toFixed(2))),
+      powerFactor: [0.9 + Math.random() * 0.05, 0.92 + Math.random() * 0.05, 0.88 + Math.random() * 0.05].map(pf => parseFloat(pf.toFixed(2))),
+      temperature: parseFloat((25 + Math.random() * 10).toFixed(2)),
+    });
+  }
+  return telemetry;
+};
+
+export async function POST(request: Request) {
+  // No authentication check as per user request to make it accessible to all.
+  // In a real app, this should be heavily restricted.
+  console.log("Attempting to seed sample data. This endpoint should be restricted in production!");
+
+  try {
+    const baseDate = new Date();
+    baseDate.setDate(baseDate.getDate() - 1); // Start telemetry data from yesterday
+
+    // --- 1. Create Sample Users (if they don't exist, for ownership or reference) ---
+    // This part is optional if devices are not tied to users, or handled by default auth.
+    // For now, we'll skip creating specific users for seeding unless required.
+    // Example: ensure an ADMIN user exists
+    // await prisma.user.upsert({
+    //   where: { email: 'admin@example.com' },
+    //   update: {},
+    //   create: {
+    //     email: 'admin@example.com',
+    //     name: 'Admin User',
+    //     hashedPassword: 'somehashedpassword', // Use bcrypt in real app
+    //     role: UserRole.ADMIN,
+    //   },
+    // });
+
+
+    // --- 2. Create Sample CCMS Devices ---
+    const deviceIdsToCreate = ["CCMS-SAMPLE-001", "CCMS-SAMPLE-002", "CCMS-SAMPLE-003"];
+    const createdDeviceIds: string[] = [];
+
+    for (const deviceId of deviceIdsToCreate) {
+      const existingDevice = await prisma.cCMSDevice.findUnique({ where: { deviceId } });
+      if (existingDevice) {
+        console.log(`Device ${deviceId} already exists. Skipping creation, but will add related data if needed.`);
+        createdDeviceIds.push(existingDevice.id); // Use existing device DB ID
+        continue;
+      }
+
+      const newDevice = await prisma.cCMSDevice.create({
+        data: {
+          deviceId,
+          powerRating: "10kW",
+          voltage: "415V",
+          frequency: "50Hz",
+          incomingCurrent: "15A",
+          ipRating: "IP65",
+          status: Math.random() > 0.7 ? DeviceStatus.ONLINE : (Math.random() > 0.5 ? DeviceStatus.OFFLINE : DeviceStatus.FAULT),
+          location: {
+            coordinates: [
+              parseFloat((-122.4194 + (Math.random() - 0.5) * 0.1).toFixed(6)), // Random Lon around SF
+              parseFloat((37.7749 + (Math.random() - 0.5) * 0.1).toFixed(6))    // Random Lat around SF
+            ],
+            address: `Sample Address ${Math.floor(Math.random() * 1000)} Test Street, Sample City`,
+          },
+          security: {
+            passwordLevel1: "pass1",
+            passwordLevel2: "pass2",
+            tamperSensor: Math.random() > 0.5,
+          },
+          telemetry: generateRandomTelemetry(baseDate, 10), // Add 10 telemetry points for new devices
+          alert: Math.random() > 0.8 ? "Initial Sample Alert: Low Voltage Detected" : null,
+        },
+      });
+      createdDeviceIds.push(newDevice.id);
+      console.log(`Created sample device: ${newDevice.deviceId} (DB ID: ${newDevice.id})`);
+    }
+
+    if (createdDeviceIds.length === 0 && deviceIdsToCreate.length > 0) {
+        // This case happens if all devices already existed and no new ones were made.
+        // We can still proceed to add alerts/schedules to them if needed.
+        // For this example, we'll primarily focus on adding to newly created or specifically found ones.
+        const existingSampleDevices = await prisma.cCMSDevice.findMany({
+            where: { deviceId: { in: deviceIdsToCreate } },
+            select: { id: true }
+        });
+        createdDeviceIds.push(...existingSampleDevices.map(d => d.id));
+    }
+
+
+    // --- 3. Create Sample Alerts for these devices ---
+    if (createdDeviceIds.length > 0) {
+      const sampleAlerts = [
+        { message: "Communication Lost with Panel", level: AlertLevel.CRITICAL },
+        { message: "Overcurrent detected on Phase 2", level: AlertLevel.WARNING },
+        { message: "Scheduled maintenance upcoming", level: AlertLevel.INFO },
+        { message: "Tamper Sensor Activated", level: AlertLevel.CRITICAL },
+        { message: "Firmware update available", level: AlertLevel.INFO },
+      ];
+
+      for (const deviceDbId of createdDeviceIds) {
+        // Add 1-2 random alerts to each sample device
+        for (let i = 0; i < Math.floor(Math.random() * 2) + 1; i++) {
+          const randomAlert = sampleAlerts[Math.floor(Math.random() * sampleAlerts.length)];
+          await prisma.alert.create({
+            data: {
+              deviceId: deviceDbId,
+              message: `${randomAlert.message} (Device ${await prisma.cCMSDevice.findUnique({where: {id: deviceDbId}, select: {deviceId: true}}).then(d => d?.deviceId)})`,
+              level: randomAlert.level,
+              createdAt: new Date(baseDate.getTime() + Math.random() * 24 * 60 * 60000) // Random time in the last day
+            },
+          });
+        }
+      }
+      console.log(`Added sample alerts for ${createdDeviceIds.length} devices.`);
+    }
+
+    // --- 4. Create Sample Schedules for these devices ---
+    if (createdDeviceIds.length > 0) {
+      for (const deviceDbId of createdDeviceIds) {
+        // Add 1-2 sample schedules
+        for (let i = 0; i < Math.floor(Math.random() * 2) + 1; i++) {
+          const startTime = new Date();
+          startTime.setHours(Math.floor(Math.random() * 10) + 18, 0, 0, 0); // Evening start
+          const endTime = new Date(startTime.getTime() + (Math.floor(Math.random() * 4) + 4) * 60 * 60000); // 4-8 hours duration
+
+          await prisma.schedule.create({
+            data: {
+              deviceId: deviceDbId,
+              startTime,
+              endTime,
+              mode: Math.random() > 0.5 ? ScheduleMode.AUTO : ScheduleMode.TWILIGHT,
+            },
+          });
+        }
+      }
+      console.log(`Added sample schedules for ${createdDeviceIds.length} devices.`);
+    }
+
+    return NextResponse.json({ message: "Sample data seeding initiated. Check server logs and application for new data." }, { status: 200 });
+
+  } catch (error: any) {
+    console.error("Error seeding sample data:", error);
+    return NextResponse.json({ error: "Failed to seed sample data.", details: error.message }, { status: 500 });
+  }
+}

--- a/Portal/app/components/NavBar/Navbar.tsx
+++ b/Portal/app/components/NavBar/Navbar.tsx
@@ -46,6 +46,15 @@ const Navbar: React.FC<NavBarProps> = ({ currentUser, totalAlerts }) => {
               >
                 All Alerts
               </button>
+              {/* Temporary link for Sample Data Page - Consider removing or restricting for production */}
+              {process.env.NODE_ENV === 'development' && ( // Only show in development
+                <button
+                  onClick={() => router.push('/sample-data')}
+                  className="text-xs font-medium text-yellow-600 dark:text-yellow-400 hover:text-yellow-700 dark:hover:text-yellow-300 transition-colors border border-yellow-500 dark:border-yellow-500 px-2 py-1 rounded-md"
+                >
+                  Sample Data
+                </button>
+              )}
             </div>
             <div className="flex-grow"></div>
             <div>

--- a/Portal/app/sample-data/page.tsx
+++ b/Portal/app/sample-data/page.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import React, { useState } from 'react';
+import axios from 'axios';
+import toast from 'react-hot-toast';
+import Container from '@/app/components/container';
+import Heading from '@/app/components/Heading';
+import ClientOnly from '@/app/components/ClientOnly';
+import Button from '@/app/components/Button'; // Assuming a generic Button component exists
+
+const SampleDataPage = () => {
+  const [isLoading, setIsLoading] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSeedData = async () => {
+    setIsLoading(true);
+    setMessage(null);
+    setError(null);
+    toast.loading('Attempting to add sample data to the database...', { id: 'seeding-toast' });
+
+    try {
+      const response = await axios.post('/api/seed-sample-data');
+      setMessage(response.data.message || 'Sample data seeding process initiated successfully. Check application and server logs.');
+      toast.success('Sample data seeding initiated!', { id: 'seeding-toast' });
+    } catch (err: any) {
+      console.error("Failed to seed sample data:", err);
+      const errorMsg = err.response?.data?.error || err.message || 'An unknown error occurred while seeding data.';
+      setError(errorMsg);
+      toast.error(`Seeding failed: ${errorMsg}`, { id: 'seeding-toast' });
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <ClientOnly>
+      <Container>
+        <div className="max-w-2xl mx-auto py-10">
+          <Heading
+            title="Sample Data Management"
+            subtitle="Use this page to populate the database with sample data for development and testing."
+            center
+          />
+
+          <div className="mt-8 p-6 bg-white dark:bg-neutral-800 shadow-xl rounded-lg text-center">
+            <h2 className="text-xl font-semibold mb-4 text-neutral-700 dark:text-neutral-200">
+              Add Predefined Sample Data Set
+            </h2>
+            <p className="mb-6 text-sm text-gray-600 dark:text-gray-400">
+              Clicking the button below will add a predefined set of sample CCMS devices,
+              along with associated telemetry records, alerts, and schedules.
+              This is useful for populating a fresh database for demonstration or testing.
+              If sample devices (e.g., CCMS-SAMPLE-001) already exist, they might be skipped or updated.
+            </p>
+
+            {/* Using a generic div styled as a button if Button component is too specific */}
+            <button
+              onClick={handleSeedData}
+              disabled={isLoading}
+              className="
+                px-6 py-3
+                bg-blue-600
+                text-white
+                font-semibold
+                rounded-lg
+                shadow-md
+                hover:bg-blue-700
+                focus:outline-none
+                focus:ring-2
+                focus:ring-blue-500
+                focus:ring-opacity-75
+                disabled:opacity-50
+                disabled:cursor-not-allowed
+                transition ease-in-out duration-150
+              "
+            >
+              {isLoading ? 'Seeding Data...' : 'Add Sample Data to Database'}
+            </button>
+
+            {message && (
+              <div className="mt-6 p-3 bg-green-100 dark:bg-green-800/30 border border-green-300 dark:border-green-600 text-green-700 dark:text-green-200 rounded-md text-sm">
+                {message}
+              </div>
+            )}
+            {error && (
+              <div className="mt-6 p-3 bg-red-100 dark:bg-red-800/30 border border-red-300 dark:border-red-600 text-red-700 dark:text-red-200 rounded-md text-sm">
+                Error: {error}
+              </div>
+            )}
+            <div className="mt-6 text-xs text-gray-500 dark:text-gray-400">
+              <p><strong>Note:</strong> This operation directly modifies the database.</p>
+              <p>Ensure you are in a development or testing environment.</p>
+              <p>The process might take a few moments to complete.</p>
+            </div>
+          </div>
+        </div>
+      </Container>
+    </ClientOnly>
+  );
+};
+
+export default SampleDataPage;


### PR DESCRIPTION
Implemented a feature to populate the database with sample data for development and testing purposes.

Key changes:

1.  **API Endpoint for Seeding:**
    - Created `POST /api/seed-sample-data`.
    - This endpoint generates and inserts sample CCMS devices (e.g., CCMS-SAMPLE-001, -002, -003) if they don't already exist.
    - For each sample device, it also creates associated sample telemetry data, alerts (various levels), and schedules (various modes).
    - The endpoint logs its actions to the server console.

2.  **Frontend Page for Seeding:**
    - Created a new page at `/sample-data`.
    - This page provides a button to trigger the data seeding API.
    - It includes loading indicators and displays success or error messages to the user via on-page messages and toast notifications.

3.  **Navbar Link (Development Only):**
    - Added a link to the `/sample-data` page in the main Navbar.
    - This link is conditionally rendered and will only be visible when `process.env.NODE_ENV === 'development'`, preventing accidental access in production.

This feature allows developers and testers to quickly populate the database with a consistent set of diverse sample data, facilitating easier development and demonstration of the application's features.